### PR TITLE
Add command 'ba' for breaking on memory access

### DIFF
--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -185,6 +185,22 @@ def bp(where):
 def bp(where):
     gdb.execute('break *%#x' % int(where))
 
+@pwndbg.commands.Command
+@pwndbg.commands.OnlyWhenRunning
+def ba(kind='r', where=None):
+    '''Break on memory access to address'''
+    commands = {'r': 'awatch',
+                'w': 'watch'}
+    if len(kind) > 1:
+        kind = kind[0]
+
+    command = commands.get(kind, None)
+    if not command:
+        print("Type of access breakpoint not recognized: %s" % kind)
+        return
+
+    gdb.execute('%s *%#x' % (command, int(where, 16)))
+
 @pwndbg.commands.ParsedCommand
 @pwndbg.commands.OnlyWhenRunning
 def u(where=None, n=5):


### PR DESCRIPTION
Mimic windbg's `ba` command to break on memory access.

`ba` contains two types:
* break on read/watch - `ba r deadbeef`
* break on watch - `ba w deadbeef`