### PR TITLE
Add 'dc' alias for 'hexdump'

### DIFF
--- a/pwndbg/commands/windbg.py
+++ b/pwndbg/commands/windbg.py
@@ -58,6 +58,10 @@ def dq(address, count=8):
     """
     return dX(8, int(address), int(count))
 
+@pwndbg.commands.ParsedCommand
+@pwndbg.commands.OnlyWhenRunning
+def dc(address, count=8):
+    return pwndbg.commands.hexdump.hexdump(address=address, count=count)
 
 def dX(size, address, count, to_string=False):
     """


### PR DESCRIPTION
Allows for easier hexdump access and keeping true with porting windbg commands over to pwndbg

