### PR TITLE
should fix the issue with home and end keys not working if the prompt…

### DIFF
--- a/pwndbg/__init__.py
+++ b/pwndbg/__init__.py
@@ -76,14 +76,8 @@ __all__ = [
 'vmmap'
 ]
 
-# If the prompt is colorized, then the home and end keys
-# don't work properly when on the prompt line.
-#
-# Instead, we set the prompt to be very plain.
-#
-# prompt = pwndbg.color.red('pwn> ')
-# prompt = pwndbg.color.bold(prompt)
-prompt = 'pwn> '
+prompt = pwndbg.color.red('pwn> ')
+prompt = pwndbg.color.bold(prompt)
 
 pre_commands = """
 set confirm off

--- a/pwndbg/color.py
+++ b/pwndbg/color.py
@@ -2,17 +2,19 @@ import gdb
 import pwndbg.enhance
 import pwndbg.vmmap
 
-NORMAL         = "\x1b[0m"
-BLACK          = "\x1b[30m"
-RED            = "\x1b[31m"
-GREEN          = "\x1b[32m"
-YELLOW         = "\x1b[33m"
-BLUE           = "\x1b[34m"
-PURPLE         = "\x1b[35m"
-CYAN           = "\x1b[36m"
-GREY = GRAY    = "\x1b[90m"
-BOLD           = "\x1b[1m"
-UNDERLINE      = "\x1b[4m"
+SOH            = "\x01"
+STX            = "\x02"
+NORMAL         = SOH + "\x1b[0m" + STX
+BLACK          = SOH + "\x1b[30m" + STX
+RED            = SOH + "\x1b[31m" + STX
+GREEN          = SOH + "\x1b[32m" + STX
+YELLOW         = SOH + "\x1b[33m" + STX
+BLUE           = SOH + "\x1b[34m" + STX
+PURPLE         = SOH + "\x1b[35m" + STX
+CYAN           = SOH + "\x1b[36m" + STX
+GREY = GRAY    = SOH + "\x1b[90m" + STX
+BOLD           = SOH + "\x1b[1m" + STX
+UNDERLINE      = SOH + "\x1b[4m" + STX
 
 STACK = YELLOW
 HEAP  = BLUE
@@ -65,4 +67,3 @@ def legend():
         UNDERLINE + 'RWX' + NORMAL,
         'RODATA'
     ))
-


### PR DESCRIPTION
… is colorized

I can't reproduce the error, so I'm not sure if this fixes it.  Bash at least need start of start of heading (SOH) and start of text (STX) around escape sequences to work properly.