### PR TITLE
Add better features to search and searchmem function by resolving some issues.

### DIFF
--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -13,17 +13,31 @@ import pwndbg.vmmap
 
 @pwndbg.commands.Command
 @pwndbg.commands.OnlyWhenRunning
-def search(value):
+def search(searchtype, value=None):
     """
     Search memory for the specified value, provided
     either as a pointer-width integer, or a string.
 
     > search 0xdeadbeef
     > search "/bin/sh"
+    
+    To search 1234 in a character string instead of integer
+    > search/c 1234
+    
+    To search for characters using hex values in string
+    > search/xc f0f1f2f3
+    > search/xc \xf0\xf1\xf2\xf3
+    > search/xc \\xf0\\xf1\\xf2\\xf3
     """
+    
+    if value:
+        searchtype = searchtype[1:]
+    else:
+        value, searchtype = searchtype, value
+    
     hits = set()
 
-    for address in pwndbg.search.search(value):
+    for address in pwndbg.search.search(value, searchtype):
         if not address:
             continue
 
@@ -47,12 +61,23 @@ def search(value):
 
 @pwndbg.commands.Command
 @pwndbg.commands.OnlyWhenRunning
-def searchmem(value):
+def searchmem(searchtype, value=None):
     """
     Search memory for the specified value, provided
     either as a pointer-width integer, or a string.
 
     > search 0xdeadbeef
     > search "/bin/sh"
+    
+    To search 1234 in a character string instead of integer
+    > search/c 1234
+    
+    To search for characters using hex values in string
+    > search/xc f0f1f2f3
+    > search/xc \xf0\xf1\xf2\xf3
+    > search/xc \\xf0\\xf1\\xf2\\xf3
     """
-    return search(value)
+    if value:
+        return search(searchtype, value)
+    else:
+        return search(searchtype)

--- a/pwndbg/commands/search.py
+++ b/pwndbg/commands/search.py
@@ -11,33 +11,10 @@ import pwndbg.search
 import pwndbg.vmmap
 
 
-@pwndbg.commands.Command
-@pwndbg.commands.OnlyWhenRunning
-def search(searchtype, value=None):
-    """
-    Search memory for the specified value, provided
-    either as a pointer-width integer, or a string.
-
-    > search 0xdeadbeef
-    > search "/bin/sh"
-    
-    To search 1234 in a character string instead of integer
-    > search/c 1234
-    
-    To search for characters using hex values in string
-    > search/xc f0f1f2f3
-    > search/xc \xf0\xf1\xf2\xf3
-    > search/xc \\xf0\\xf1\\xf2\\xf3
-    """
-    
-    if value:
-        searchtype = searchtype[1:]
-    else:
-        value, searchtype = searchtype, value
-    
+def print_search(value):
     hits = set()
 
-    for address in pwndbg.search.search(value, searchtype):
+    for address in pwndbg.search.search(value):
         if not address:
             continue
 
@@ -46,7 +23,7 @@ def search(searchtype, value=None):
 
         hits.add(address)
 
-        vmmap  = pwndbg.vmmap.find(address)
+        vmmap = pwndbg.vmmap.find(address)
         if vmmap:
             region = os.path.basename(vmmap.objfile)
         else:
@@ -61,23 +38,106 @@ def search(searchtype, value=None):
 
 @pwndbg.commands.Command
 @pwndbg.commands.OnlyWhenRunning
-def searchmem(searchtype, value=None):
+def search(searchtype, value=None):
     """
     Search memory for the specified value, provided
     either as a pointer-width integer, or a string.
 
     > search 0xdeadbeef
     > search "/bin/sh"
-    
+
     To search 1234 in a character string instead of integer
     > search/c 1234
-    
+
     To search for characters using hex values in string
-    > search/xc f0f1f2f3
-    > search/xc \xf0\xf1\xf2\xf3
-    > search/xc \\xf0\\xf1\\xf2\\xf3
+    > search/x f0f1f2f3
+    > search/x \\xf0\\xf1\\xf2\\xf3
+    > search/x \\\\xf0\\\\xf1\\\\xf2\\\\xf3
     """
     if value:
-        return search(searchtype, value)
+        searchtype = searchtype[1:]
     else:
-        return search(searchtype)
+        value, searchtype = searchtype, value
+
+    if searchtype:
+        if searchtype == 'c' or searchtype == 'x':
+            searchtype = '/' + searchtype
+            searchb(searchtype,value)
+            return
+        else:
+            print(pwndbg.color.red("Invalid option {0}".format(searchtype)))
+            return
+
+    if value.isdigit():
+        value = int(value)
+    elif value.startswith('0x') \
+    and all(c in 'xABCDEFabcdef0123456789' for c in value):
+        value = int(value, 16)
+
+    if isinstance(value, (long, int)):
+        if pwndbg.arch.ptrsize == 4:
+            value = struct.pack('I', value)
+        elif pwndbg.arch.ptrsize == 8:
+            value = struct.pack('L', value)
+
+    print_search(value)
+
+@pwndbg.commands.Command
+@pwndbg.commands.OnlyWhenRunning
+def searchmem(searchtype, searchvalue=None):
+    """
+    Search memory for the specified value, provided
+    either as a pointer-width integer, or a string.
+
+    > searchmem 0xdeadbeef
+    > searchmem "/bin/sh"
+
+    To search 1234 in a character string instead of integer
+    > searchmem/c 1234
+
+    To search for characters using hex values in string
+    > searchmem/x f0f1f2f3
+    > searchmem/x \\xf0\\xf1\\xf2\\xf3
+    > searchmem/x \\\\xf0\\\\xf1\\\\xf2\\\\xf3
+    """
+    return search(searchtype,searchvalue)
+
+@pwndbg.commands.Command
+@pwndbg.commands.OnlyWhenRunning
+def searchb(searchtype, value=None):
+    """
+    Search memory for the specified value, provided
+    as a string of characters or hexadecimal values.
+
+    > searchb 1234
+
+    To search for characters using hex values in string
+    > searchb/x f0f1f2f3
+    > searchb/x \\xf0\\xf1\\xf2\\xf3
+    > searchb/x \\\\xf0\\\\xf1\\\\xf2\\\\xf3
+    """
+    if value:
+        searchtype = searchtype[1:]
+    else:
+        value, searchtype = searchtype, value
+
+    if searchtype == 'x':
+        if '\\x' in value:
+            value = bytes.fromhex(''.join(value.split('\\x')))
+        elif 'x' in value:
+            value = bytes.fromhex(''.join(value.split('x')))
+        else:
+            value = bytes.fromhex(''.join(value[i:i+2]
+                                          for i in range(0, len(value), 2)))
+    print_search(value)
+
+@pwndbg.commands.Command
+@pwndbg.commands.OnlyWhenRunning
+def searchd(value):
+    """
+    Searches memory for the specified value,
+    provided as a pointer-width integer.
+
+    > searchd 0xdeadbeef
+    """
+    return search(value)

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -12,21 +12,31 @@ import pwndbg.typeinfo
 import pwndbg.vmmap
 
 
-def search(searchfor):
+def search(searchfor, searchtype=None):
     value = searchfor
     size  = None
 
-    if searchfor.isdigit():
-        searchfor = int(searchfor)
-    elif searchfor.startswith('0x') \
-    and all(c in 'xABCDEFabcdef0123456789' for c in searchfor):
-        searchfor = int(searchfor, 16)
+    if searchtype != 'c' and searchtype != 'xc':
+        if searchfor.isdigit():
+            searchfor = int(searchfor)
+        elif searchfor.startswith('0x') \
+        and all(c in 'xABCDEFabcdef0123456789' for c in searchfor):
+            searchfor = int(searchfor, 16)
 
-    if isinstance(searchfor, (long, int)):
-        if pwndbg.arch.ptrsize == 4:
-            searchfor = struct.pack('I', searchfor)
-        elif pwndbg.arch.ptrsize == 8:
-            searchfor = struct.pack('L', searchfor)
+        if isinstance(searchfor, (long, int)):
+            if pwndbg.arch.ptrsize == 4:
+                searchfor = struct.pack('I', searchfor)
+            elif pwndbg.arch.ptrsize == 8:
+                searchfor = struct.pack('L', searchfor)
+
+    elif searchtype == 'xc':
+        if '\\x' in searchfor:
+            searchfor = bytes.fromhex(''.join(searchfor.split('\\x')))
+        elif 'x' in searchfor:
+            searchfor = bytes.fromhex(''.join(searchfor.split('x')))
+        else:
+            searchfor = bytes.fromhex(''.join(searchfor[i:i+2]
+                                          for i in range(0, len(searchfor), 2)))
 
     i = gdb.selected_inferior()
 

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Search the address space for byte patterns or pointer values.
+Search the address space for byte patterns.
 """
 import struct
 
@@ -12,31 +12,9 @@ import pwndbg.typeinfo
 import pwndbg.vmmap
 
 
-def search(searchfor, searchtype=None):
+def search(searchfor):
     value = searchfor
     size  = None
-
-    if searchtype != 'c' and searchtype != 'xc':        #default search when used without any searchtype of invalid search type
-        if searchfor.isdigit():
-            searchfor = int(searchfor)
-        elif searchfor.startswith('0x') \
-        and all(c in 'xABCDEFabcdef0123456789' for c in searchfor):
-            searchfor = int(searchfor, 16)
-
-        if isinstance(searchfor, (long, int)):
-            if pwndbg.arch.ptrsize == 4:
-                searchfor = struct.pack('I', searchfor)
-            elif pwndbg.arch.ptrsize == 8:
-                searchfor = struct.pack('L', searchfor)
-
-    elif searchtype == 'xc':
-        if '\\x' in searchfor:
-            searchfor = bytes.fromhex(''.join(searchfor.split('\\x')))
-        elif 'x' in searchfor:
-            searchfor = bytes.fromhex(''.join(searchfor.split('x')))
-        else:
-            searchfor = bytes.fromhex(''.join(searchfor[i:i+2]
-                                          for i in range(0, len(searchfor), 2)))
 
     i = gdb.selected_inferior()
 

--- a/pwndbg/search.py
+++ b/pwndbg/search.py
@@ -16,7 +16,7 @@ def search(searchfor, searchtype=None):
     value = searchfor
     size  = None
 
-    if searchtype != 'c' and searchtype != 'xc':
+    if searchtype != 'c' and searchtype != 'xc':        #default search when used without any searchtype of invalid search type
         if searchfor.isdigit():
             searchfor = int(searchfor)
         elif searchfor.startswith('0x') \


### PR DESCRIPTION
While searching for `123456` in the the memory using either of `search` or `searchmem` as:
```
pwndbg> search 123456
pwndbg> search '123456'
```
it would convert the 123456 to integer and search for the corresponding hex values in memory. If the user want to search `123456` that was inserted into character array, it was not efficient to use the `search` or `searchmem` with their existing way of working.

Hence, I made this patch to solve this issue by letting the user to input what way he wants to search `123456` as. Hence I added a support for character search in such case which can be fulfilled as:
```
pwndbg> search/c 123456
pwndbg> search/c '123456'
```

Also the support to search directly for hex characters in memory is added in case user wants to search for any arbitrary hex value such as `\xf0\xf1\xf2\xf3` in memory which might have been injected into character array.
```
pwndbg> search/xc "f0f1f2f3"
pwndbg> search/xc "\xf0\xf1\xf2\xf3"
pwndbg> search/xc "\\xf0\\xf1\\xf2\\xf3"
```
The use of `\\xf0` is done because by default when the argument was send to function, gdb used to take `\` as escaping character and instead send `xf0xf1xf2xf3` for input `\xf0\xf1\xf2\xf3`. Hence if user is cautious and tries to send `\\xf0\\xf1\\xf2\\xf3` so that function gets parameter value as `\xf0\xf1\xf2\xf3`, it would be handled correctly.