### PR TITLE
file.get() returns bytes, autofetch() needs to also write bytes to it…

### DIFF
--- a/pwndbg/symbol.py
+++ b/pwndbg/symbol.py
@@ -89,7 +89,7 @@ def autofetch():
         filename = os.path.basename(objfile)
         local_path = os.path.join(remote_files_dir, filename)
 
-        with open(local_path, 'w+') as f:
+        with open(local_path, 'wb+') as f:
             f.write(data)
 
         remote_files[objfile] = local_path


### PR DESCRIPTION
Running a small snippet of code for http://www.xorpd.net/pages/xchg_rax/snip_00.html

```
from pwn import *
context.terminal = ['tmux', 'splitw', '-h']

init_str = """
mov ecx, 10
"""

asm_str = """
xor      eax,eax
loop     $
mov      edx,0
and      esi,0
sub      edi,edi
"""

r = gdb.debug_shellcode(asm(init_str + asm_str))

r.interactive()
```

Previous error:
```
File "/home/vagrant/tools/pwndbg/pwndbg/events.py", line 97, in caller
    func()
File "/home/vagrant/tools/pwndbg/pwndbg/symbol.py", line 93, in autofetch
    f.write(data)
TypeError: must be str, not bytes
Python Exception <class 'TypeError'> must be str, not bytes:
```

Just needed to write bytes instead of a string in `autofetch`