### PR TITLE
Fix .gdbinit modification line

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -29,5 +29,5 @@ done
 
 # Load Pwndbg into GDB on every launch.
 if ! grep pwndbg ~/.gdbinit &>/dev/null; then
-    echo "source $PWD/pwndbg/gdbinit.py" >> ~/.gdbinit
+    echo "source $PWD/gdbinit.py" >> ~/.gdbinit
 fi


### PR DESCRIPTION
Your install instructions say to cd into the top level pwndbg directory and run ./setup.sh. This causes your last popd on line 27 to put you back there, and then line 32 adds an extra /pwndbg/ to the path of gdbinit.py so gdb can't find it on launch.